### PR TITLE
Add sample C, Python, and assembly programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # codex-testing
+
 testing codex OPENAI
+
+This repository now contains simple examples in multiple languages under the
+`src` directory. See `src/README.md` for build and run instructions.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,32 @@
+# Sample Programs
+
+This directory contains examples in C, Python, and x86-64 Assembly.
+
+## Building and Running
+
+### C
+
+Compile the C program with:
+
+```bash
+gcc hello.c -o hello_c
+./hello_c
+```
+
+### Python
+
+Run the Python script:
+
+```bash
+python hello.py
+```
+
+### Assembly
+
+The assembly example uses [NASM](https://www.nasm.us) for assembly and `ld` for linking:
+
+```bash
+nasm -f elf64 hello.asm -o hello.o
+ld hello.o -o hello_asm
+./hello_asm
+```

--- a/src/hello.asm
+++ b/src/hello.asm
@@ -1,0 +1,17 @@
+section .data
+    msg db "Hello from Assembly!", 10
+    len equ $ - msg
+
+section .text
+    global _start
+
+_start:
+    mov rax, 1         ; sys_write
+    mov rdi, 1         ; file descriptor (stdout)
+    mov rsi, msg       ; pointer to message
+    mov rdx, len       ; message length
+    syscall
+
+    mov rax, 60        ; sys_exit
+    xor rdi, rdi       ; exit code 0
+    syscall

--- a/src/hello.c
+++ b/src/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello from C!\n");
+    return 0;
+}

--- a/src/hello.py
+++ b/src/hello.py
@@ -1,0 +1,5 @@
+def main():
+    print("Hello from Python!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README reference to new sample programs in `src`
- provide a `src/README.md` with build instructions
- add `hello.c`, `hello.py`, and `hello.asm`

## Testing
- `pytest -q`
- `make test` *(fails: No rule to make target)*


------
https://chatgpt.com/codex/tasks/task_e_68402de15fc0832e93e225ea7e0b311f