### PR TITLE
Add code examples in C, Python and assembly

### DIFF
--- a/code/hello.asm
+++ b/code/hello.asm
@@ -1,0 +1,29 @@
+section .data
+fmt db "Hello, %s!", 10, 0
+default_name db "world",0
+
+section .text
+global main
+extern printf
+
+main:
+    push rbp
+    mov rbp, rsp
+    mov rax, rdi    ; argc
+    mov rbx, rsi    ; argv
+    cmp rax, 2
+    jl .use_default
+    mov rdi, fmt
+    mov rsi, [rbx+8] ; argv[1]
+    xor eax, eax
+    call printf
+    jmp .done
+.use_default:
+    mov rdi, fmt
+    mov rsi, default_name
+    xor eax, eax
+    call printf
+.done:
+    mov eax, 0
+    leave
+    ret

--- a/code/hello.c
+++ b/code/hello.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    if (argc > 1) {
+        printf("Hello, %s!\n", argv[1]);
+    } else {
+        printf("Hello, world!\n");
+    }
+    return 0;
+}

--- a/code/hello.py
+++ b/code/hello.py
@@ -1,0 +1,11 @@
+import sys
+
+def main():
+    if len(sys.argv) > 1:
+        name = sys.argv[1]
+    else:
+        name = "world"
+    print(f"Hello, {name}!")
+
+if __name__ == "__main__":
+    main()

--- a/paper.tex
+++ b/paper.tex
@@ -23,6 +23,41 @@ Detail your research approach and methods.
 \section{Experiments}
 Provide experiments, results, and analysis.
 
+\section{Code Examples}
+This appendix accompanies the repository and describes how to build and
+execute the included examples written in C, Python, and x86\textendash64
+assembly. Each program prints a greeting using an optional name
+parameter supplied on the command line.
+
+\subsection{C Program}
+The source file \verb|code/hello.c| may be compiled using GCC as
+follows:
+\begin{verbatim}
+gcc -o hello_c code/hello.c
+\end{verbatim}
+Running \verb|./hello_c| prints \texttt{``Hello, world!''}. Supplying a
+name argument, e.g. \verb|./hello_c Alice|, results in the output
+\texttt{``Hello, Alice!''}.
+
+\subsection{Python Program}
+The script \verb|code/hello.py| requires Python~3 and is executed with:
+\begin{verbatim}
+python3 code/hello.py [name]
+\end{verbatim}
+If a name is provided, the program prints a personalized greeting; otherwise,
+it defaults to \texttt{``Hello, world!''}.
+
+\subsection{Assembly Program}
+An x86\textendash64 NASM example is provided in \verb|code/hello.asm|.
+It can be assembled and linked with:
+\begin{verbatim}
+nasm -felf64 code/hello.asm
+gcc hello.o -o hello_asm
+\end{verbatim}
+Executing \verb|./hello_asm Bob| prints the message
+\texttt{``Hello, Bob!''}. If no parameter is supplied, the default output is
+\texttt{``Hello, world!''}.
+
 \section{Conclusion}
 Summarize your findings and future work.
 


### PR DESCRIPTION
## Summary
- add `hello.c`, `hello.py` and `hello.asm` examples
- document compilation and usage in `paper.tex`

## Testing
- `gcc -o code/hello_c code/hello.c`
- `./code/hello_c Codex`
- `python3 code/hello.py Test`
- `nasm -felf64 code/hello.asm -o hello.o`
- `gcc -no-pie hello.o -o hello_asm`
- `./hello_asm Demo`


------
https://chatgpt.com/codex/tasks/task_e_68402fb76fe8832e87bad0549dbea4dd