### PR TITLE
Add simple cipher analysis tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Cipher Analysis Examples
+
+This repository now includes simple cipher analysis tools in four languages:
+
+- `python/`: command line utilities for Caesar, Vigenère, and a simplified Enigma simulator.
+- `c/`: minimal CLI tool demonstrating Caesar and Vigenère breaking.
+- `asm/`: x86-64 assembly program to brute force Caesar.
+- `bash/`: shell script performing basic Caesar and Vigenère operations.
+
+Each directory contains a README with usage examples.

--- a/asm/README.md
+++ b/asm/README.md
@@ -1,0 +1,9 @@
+# Assembly Caesar Breaker
+
+An example x86-64 assembly program that prints all 26 shifts of a Caesar cipher.
+
+```
+nasm -felf64 caesar.asm
+ld caesar.o -o caesar
+./caesar
+```

--- a/asm/caesar.asm
+++ b/asm/caesar.asm
@@ -1,0 +1,79 @@
+; Simple x86-64 assembly program to brute force Caesar cipher
+; nasm -felf64 caesar.asm && ld caesar.o -o caesar
+
+section .data
+    prompt db "Ciphertext: ", 0
+
+section .bss
+    buf resb 256
+
+section .text
+    global _start
+
+_start:
+    ; print prompt
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, prompt
+    mov rdx, 11
+    syscall
+
+    ; read input
+    mov rax, 0
+    mov rdi, 0
+    mov rsi, buf
+    mov rdx, 256
+    syscall
+    mov rbx, rax ; length
+
+    xor rcx, rcx ; shift
+next_shift:
+    mov rdi, buf
+    mov rsi, rbx
+    call print_shift
+    inc rcx
+    cmp rcx, 26
+    jl next_shift
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+print_shift:
+    push rbx
+    push rcx
+    mov rax, 1
+    mov rdi, 1
+    mov rdx, rbx
+.loop:
+    mov al, byte [rdi+rsi-1]
+    cmp al, 'A'
+    jb .write
+    cmp al, 'Z'
+    ja .write
+    sub al, 'A'
+    sub al, cl
+    add al, 26
+    mov bl, 26
+    div bl
+    add al, 'A'
+.write:
+    mov byte [rdi+rsi-1], al
+    dec rdx
+    jnz .loop
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, buf
+    mov rdx, rbx
+    syscall
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, newline
+    mov rdx, 1
+    syscall
+    pop rcx
+    pop rbx
+    ret
+
+section .data
+    newline db 10

--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,8 @@
+# Bash Cipher Utilities
+
+Simple shell script to try all shifts of a Caesar cipher or decrypt with a given Vigenère key.
+
+```
+./analyze.sh caesar "OLSSV DVYSK"
+./analyze.sh vigenere "LXFOPVEFRNHR" KEY
+```

--- a/bash/analyze.sh
+++ b/bash/analyze.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+command=$1
+text=$2
+
+alphabet=ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+caesar_break() {
+    for shift in {0..25}; do
+        result=""
+        for ((i=0;i<${#text};i++)); do
+            char=${text:i:1}
+            idx=$(expr index "$alphabet" "${char^^}")
+            if [ $idx -gt 0 ]; then
+                idx=$(( (idx - 1 - shift + 26) % 26 ))
+                result+=${alphabet:idx:1}
+            else
+                result+=$char
+            fi
+        done
+        echo "$shift: $result"
+    done
+}
+
+vigenere_decrypt() {
+    key=$3
+    keylen=${#key}
+    result=""
+    k=0
+    for ((i=0;i<${#text};i++)); do
+        char=${text:i:1}
+        idx=$(expr index "$alphabet" "${char^^}")
+        if [ $idx -gt 0 ]; then
+            shift=$(expr index "$alphabet" "${key:k:1}")
+            shift=$((shift - 1))
+            idx=$(( (idx - 1 - shift + 26) % 26 ))
+            result+=${alphabet:idx:1}
+            k=$(( (k + 1) % keylen ))
+        else
+            result+=$char
+        fi
+    done
+    echo "$result"
+}
+
+case $command in
+    caesar)
+        caesar_break
+        ;;
+    vigenere)
+        vigenere_decrypt "$text" "$3"
+        ;;
+    *)
+        echo "Usage: $0 {caesar|vigenere} TEXT [KEY]"
+        ;;
+esac
+

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,0 +1,16 @@
+CC=gcc
+CFLAGS=-Wall -O2
+
+all: cipher_tool
+
+cipher_tool: main.o ciphers.o
+	$(CC) $(CFLAGS) -o cipher_tool main.o ciphers.o
+
+main.o: main.c ciphers.h
+	$(CC) $(CFLAGS) -c main.c
+
+ciphers.o: ciphers.c ciphers.h
+	$(CC) $(CFLAGS) -c ciphers.c
+
+clean:
+	rm -f *.o cipher_tool

--- a/c/README.md
+++ b/c/README.md
@@ -1,0 +1,9 @@
+# C Cipher Analysis
+
+A minimal CLI program to experiment with Caesar and Vigenere cipher breaking.
+
+```
+make
+./cipher_tool caesar "L ORYH FLSKHUV"
+./cipher_tool vigenere "LXFOPVEFRNHR" 3
+```

--- a/c/ciphers.c
+++ b/c/ciphers.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <string.h>
+#include "ciphers.h"
+
+void caesar_break(const char *ciphertext) {
+    for (int shift = 0; shift < 26; ++shift) {
+        for (const char *p = ciphertext; *p; ++p) {
+            if (*p >= 'A' && *p <= 'Z')
+                putchar('A' + (*p - 'A' - shift + 26) % 26);
+            else if (*p >= 'a' && *p <= 'z')
+                putchar('a' + (*p - 'a' - shift + 26) % 26);
+            else
+                putchar(*p);
+        }
+        printf("\n");
+    }
+}
+
+void vigenere_break(const char *ciphertext, int key_length) {
+    size_t len = strlen(ciphertext);
+    char key[key_length + 1];
+    for (int i = 0; i < key_length; ++i) {
+        int counts[26] = {0};
+        for (size_t j = i; j < len; j += key_length) {
+            char c = ciphertext[j];
+            if (c >= 'A' && c <= 'Z')
+                counts[c - 'A']++;
+        }
+        int max = 0, idx = 0;
+        for (int k = 0; k < 26; ++k) {
+            if (counts[k] > max) {
+                max = counts[k];
+                idx = k;
+            }
+        }
+        key[i] = 'A' + (idx - ('E' - 'A') + 26) % 26;
+    }
+    key[key_length] = '\0';
+    printf("Estimated key: %s\n", key);
+}

--- a/c/ciphers.h
+++ b/c/ciphers.h
@@ -1,0 +1,7 @@
+#ifndef CIPHERS_H
+#define CIPHERS_H
+
+void caesar_break(const char *ciphertext);
+void vigenere_break(const char *ciphertext, int key_length);
+
+#endif // CIPHERS_H

--- a/c/main.c
+++ b/c/main.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <string.h>
+#include "ciphers.h"
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        printf("Usage: %s <cipher> <text> [key_length]\n", argv[0]);
+        return 1;
+    }
+    const char *mode = argv[1];
+    const char *text = argv[2];
+    if (strcmp(mode, "caesar") == 0) {
+        caesar_break(text);
+    } else if (strcmp(mode, "vigenere") == 0 && argc >= 4) {
+        int key_length = atoi(argv[3]);
+        vigenere_break(text, key_length);
+    } else {
+        printf("Unsupported mode or missing arguments\n");
+    }
+    return 0;
+}

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,9 @@
+# Python Cipher Analysis
+
+This directory provides analysis tools for classic ciphers:
+
+- **Caesar**: brute force decryption of all possible shifts.
+- **Vigenere**: estimate key from frequency analysis given a key length.
+- **Enigma**: simplified rotor/plugboard simulation.
+
+Run `python analyze.py --help` for options.

--- a/python/analyze.py
+++ b/python/analyze.py
@@ -1,0 +1,117 @@
+import argparse
+from collections import Counter
+
+ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+
+def caesar_break(ciphertext):
+    ciphertext = ciphertext.upper()
+    possibilities = {}
+    for shift in range(26):
+        decrypted = ''.join(
+            ALPHABET[(ALPHABET.index(c) - shift) % 26] if c in ALPHABET else c
+            for c in ciphertext
+        )
+        possibilities[shift] = decrypted
+    return possibilities
+
+
+def vigenere_decrypt(ciphertext, key):
+    key = key.upper()
+    result = []
+    key_index = 0
+    for c in ciphertext.upper():
+        if c in ALPHABET:
+            shift = ALPHABET.index(key[key_index % len(key)])
+            index = (ALPHABET.index(c) - shift) % 26
+            result.append(ALPHABET[index])
+            key_index += 1
+        else:
+            result.append(c)
+    return ''.join(result)
+
+
+def vigenere_break(ciphertext, key_length):
+    ciphertext = ''.join(c for c in ciphertext.upper() if c in ALPHABET)
+    columns = ['' for _ in range(key_length)]
+    for i, c in enumerate(ciphertext):
+        columns[i % key_length] += c
+    key = ''
+    for col in columns:
+        freqs = Counter(col)
+        most_common = freqs.most_common(1)[0][0]
+        shift = (ALPHABET.index(most_common) - ALPHABET.index('E')) % 26
+        key += ALPHABET[shift]
+    plaintext = vigenere_decrypt(ciphertext, key)
+    return key, plaintext
+
+
+# Simple Enigma simulation with 3 rotors and plugboard
+def enigma_encrypt(text, rotors, reflector, plugboard):
+    def apply_plugboard(c):
+        return plugboard.get(c, c)
+
+    result = []
+    r_positions = [0, 0, 0]
+    for ch in text.upper():
+        if ch not in ALPHABET:
+            result.append(ch)
+            continue
+        c = apply_plugboard(ch)
+        for i in range(3):
+            offset = (ALPHABET.index(c) + r_positions[i]) % 26
+            c = rotors[i][offset]
+        c = reflector[ALPHABET.index(c)]
+        for i in reversed(range(3)):
+            offset = rotors[i].index(c)
+            c = ALPHABET[(offset - r_positions[i]) % 26]
+        c = apply_plugboard(c)
+        result.append(c)
+        r_positions[0] = (r_positions[0] + 1) % 26
+        if r_positions[0] == 0:
+            r_positions[1] = (r_positions[1] + 1) % 26
+            if r_positions[1] == 0:
+                r_positions[2] = (r_positions[2] + 1) % 26
+    return ''.join(result)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Cipher analysis tools")
+    subparsers = parser.add_subparsers(dest="command")
+
+    caesar_p = subparsers.add_parser("caesar_break")
+    caesar_p.add_argument("ciphertext")
+
+    vig_p = subparsers.add_parser("vigenere_break")
+    vig_p.add_argument("ciphertext")
+    vig_p.add_argument("key_length", type=int)
+
+    enigma_p = subparsers.add_parser("enigma_sim")
+    enigma_p.add_argument("text")
+
+    args = parser.parse_args()
+
+    if args.command == "caesar_break":
+        possibilities = caesar_break(args.ciphertext)
+        for shift, text in possibilities.items():
+            print(f"Shift {shift}: {text}")
+    elif args.command == "vigenere_break":
+        key, text = vigenere_break(args.ciphertext, args.key_length)
+        print("Estimated key:", key)
+        print("Plaintext:", text)
+    elif args.command == "enigma_sim":
+        rotors = [
+            'EKMFLGDQVZNTOWYHXUSPAIBRCJ',
+            'AJDKSIRUXBLHWTMCQGZNPYFVOE',
+            'BDFHJLCPRTXVZNYEIWGAKMUSQO'
+        ]
+        reflector = 'YRUHQSLDPXNGOKMIEBFZCWVJAT'
+        plugboard = {}
+        text = enigma_encrypt(args.text, rotors, reflector, plugboard)
+        print(text)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README with overview
- implement Caesar, Vigenère and simplified Enigma tools in Python
- provide C versions with Makefile
- add bash scripts and assembly example

## Testing
- `make -C c`
- `python python/analyze.py --help`
- `nasm -felf64 asm/caesar.asm -o asm/caesar.o && ld asm/caesar.o -o asm/caesar`
- `bash/analyze.sh caesar TEST`


------
https://chatgpt.com/codex/tasks/task_e_68402ffdca14832ea114fb1bec9f26a0