### PR TITLE
Add simple cipher implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+CFLAGS=-Wall -Wextra -O2
+ASMFLAGS=-f elf64
+
+ASMOBJS=asm/caesar.o asm/vigenere.o asm/enigma.o
+
+all: c/caesar c/vigenere c/enigma asm/caesar asm/vigenere asm/enigma
+
+c/caesar: c/caesar.c
+	$(CC) $(CFLAGS) $< -o $@
+
+c/vigenere: c/vigenere.c
+	$(CC) $(CFLAGS) $< -o $@
+
+c/enigma: c/enigma.c
+	$(CC) $(CFLAGS) $< -o $@
+
+asm/%.o: asm/%.asm
+	nasm $(ASMFLAGS) $< -o $@
+
+asm/caesar: asm/caesar.o
+	$(CC) $< -no-pie -lc -o $@
+
+asm/vigenere: asm/vigenere.o
+	$(CC) $< -no-pie -lc -o $@
+
+asm/enigma: asm/enigma.o
+	$(CC) $< -no-pie -lc -o $@
+
+clean:
+	rm -f c/caesar c/vigenere c/enigma $(ASMOBJS) asm/caesar asm/vigenere asm/enigma

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Cipher Simulators
+
+This repository contains simple implementations of Caesar, Vigenere and toy Enigma ciphers in three languages:
+
+- **Python**: located in `py/`
+- **C**: located in `c/`
+- **NASM assembly**: located in `asm/`
+
+## Building and Running
+
+### Python
+Run the scripts directly with Python 3:
+```bash
+python3 py/caesar.py 3 "HELLO"
+python3 py/vigenere.py KEY "HELLO WORLD"
+python3 py/enigma.py HELLO
+```
+
+### C
+Compile each program with a C compiler such as GCC:
+```bash
+gcc c/caesar.c -o c/caesar
+gcc c/vigenere.c -o c/vigenere
+gcc c/enigma.c -o c/enigma
+```
+Then run them:
+```bash
+./c/caesar 3 HELLO
+./c/vigenere KEY "HELLO WORLD"
+./c/enigma HELLO
+```
+
+### Assembly
+Assemble with NASM and link with GCC:
+```bash
+nasm -f elf64 asm/caesar.asm -o asm/caesar.o
+gcc asm/caesar.o -no-pie -lc -o asm/caesar
+
+nasm -f elf64 asm/vigenere.asm -o asm/vigenere.o
+gcc asm/vigenere.o -no-pie -lc -o asm/vigenere
+
+nasm -f elf64 asm/enigma.asm -o asm/enigma.o
+gcc asm/enigma.o -no-pie -lc -o asm/enigma
+```
+Run the executables:
+```bash
+./asm/caesar
+./asm/vigenere
+./asm/enigma
+```
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Cipher Simulators
 
-This repository contains simple implementations of Caesar, Vigenere and toy Enigma ciphers in three languages:
+This repository contains simple implementations of Caesar, Vigenere and toy Enigma ciphers in three languages. These examples are for educational or demonstration purposes only and should not be used for real security:
 
 - **Python**: located in `py/`
 - **C**: located in `c/`
 - **NASM assembly**: located in `asm/`
 
 ## Building and Running
+
+You can build everything at once using the included `Makefile`:
+
+```bash
+make
+```
+
+This produces executables for the C and NASM versions in their respective
+directories. You can also compile and run each language individually as shown
+below.
 
 ### Python
 Run the scripts directly with Python 3:
@@ -48,4 +58,5 @@ Run the executables:
 ./asm/vigenere
 ./asm/enigma
 ```
+
 

--- a/asm/caesar.asm
+++ b/asm/caesar.asm
@@ -1,0 +1,47 @@
+section .data
+    input db "HELLO WORLD",0
+    shift db 3
+    output db 12 dup(0)
+    fmt db "%s",10,0
+
+section .text
+    global main
+    extern printf
+
+main:
+    push rbp
+    mov rbp, rsp
+    mov rsi, input
+    mov rdi, output
+.loop:
+    mov al, [rsi]
+    test al, al
+    je .done
+    cmp al, 'A'
+    jb .copy
+    cmp al, 'Z'
+    ja .copy
+    sub al, 'A'
+    add al, [shift]
+    cmp al, 26
+    jl .nowrap
+    sub al, 26
+.nowrap:
+    add al, 'A'
+    jmp .store
+.copy:
+    mov al, [rsi]
+.store:
+    mov [rdi], al
+    inc rsi
+    inc rdi
+    jmp .loop
+.done:
+    mov byte [rdi], 0
+    mov rdi, fmt
+    mov rsi, output
+    xor eax, eax
+    call printf
+    xor eax, eax
+    leave
+    ret

--- a/asm/caesar.asm
+++ b/asm/caesar.asm
@@ -1,3 +1,5 @@
+; Simple Caesar cipher demonstration
+
 section .data
     input db "HELLO WORLD",0
     shift db 3

--- a/asm/enigma.asm
+++ b/asm/enigma.asm
@@ -1,3 +1,5 @@
+; Toy Enigma cipher demonstration
+
 section .data
     input db "HELLO",0
     rotor db "EKMFLGDQVZNTOWYHXUSPAIBRCJ"

--- a/asm/enigma.asm
+++ b/asm/enigma.asm
@@ -1,0 +1,73 @@
+section .data
+    input db "HELLO",0
+    rotor db "EKMFLGDQVZNTOWYHXUSPAIBRCJ"
+    rotor_inv db "UWYGADFPVZBECKMTHXSLRINQOJ"
+    reflector db "YRUHQSLDPXNGOKMIEBFZCWVJAT"
+    output db 6 dup(0)
+    fmt db "%s",10,0
+
+section .text
+    global main
+    extern printf
+
+main:
+    push rbp
+    mov rbp, rsp
+    mov rsi, input
+    mov rdi, output
+    xor ecx, ecx ; rotor position
+.loop:
+    mov al, [rsi]
+    test al, al
+    je .done
+    sub al, 'A'
+    mov bl, cl
+    add bl, al
+    cmp bl, 26
+    jb .step1
+    sub bl, 26
+    cmp bl, 26
+    jb .step1
+    sub bl, 26
+.step1:
+    movzx ebx, bl
+    mov bl, [rotor+rbx]
+    sub bl, 'A'
+    movzx ebx, bl
+    mov bl, [reflector+rbx]
+    sub bl, 'A'
+    movzx ebx, bl
+    mov bl, [rotor_inv+rbx]
+    sub bl, 'A'
+    movzx ebx, bl
+    cmp bl, cl
+    jb .no_borrow
+    sub bl, cl
+    jmp .sub_done
+.no_borrow:
+    ; bl < cl, so add 26 before subtract
+    add bl, 26
+    sub bl, cl
+.sub_done:
+    cmp bl, 26
+    jb .result
+    sub bl, 26
+.result:
+    add bl, 'A'
+    mov [rdi], bl
+    inc rsi
+    inc rdi
+    inc cl
+    cmp cl, 26
+    jb .loop
+    xor cl, cl
+    jmp .loop
+.done:
+    mov byte [rdi], 0
+    mov rdi, fmt
+    mov rsi, output
+    xor eax, eax
+    call printf
+    xor eax, eax
+    leave
+    ret

--- a/asm/vigenere.asm
+++ b/asm/vigenere.asm
@@ -1,3 +1,5 @@
+; Simple Vigenere cipher demonstration
+
 section .data
     input db "HELLO WORLD",0
     key db "KEY",0

--- a/asm/vigenere.asm
+++ b/asm/vigenere.asm
@@ -1,0 +1,58 @@
+section .data
+    input db "HELLO WORLD",0
+    key db "KEY",0
+    keylen equ 3
+    output db 12 dup(0)
+    fmt db "%s",10,0
+
+section .text
+    global main
+    extern printf
+
+main:
+    push rbp
+    mov rbp, rsp
+    mov rsi, input
+    mov rdi, output
+    xor ecx, ecx
+.loop:
+    mov al, [rsi]
+    test al, al
+    je .done
+    cmp al, 'A'
+    jb .copy
+    cmp al, 'Z'
+    ja .copy
+    sub al, 'A'
+    mov bl, [key+rcx]
+    sub bl, 'A'
+    add al, bl
+    cmp al, 26
+    jl .nowrap
+    sub al, 26
+.nowrap:
+    add al, 'A'
+    inc ecx
+    cmp ecx, keylen
+    jl .store
+    xor ecx, ecx
+.store:
+    mov [rdi], al
+    inc rsi
+    inc rdi
+    jmp .loop
+.copy:
+    mov al, [rsi]
+    mov [rdi], al
+    inc rsi
+    inc rdi
+    jmp .loop
+.done:
+    mov byte [rdi], 0
+    mov rdi, fmt
+    mov rsi, output
+    xor eax, eax
+    call printf
+    xor eax, eax
+    leave
+    ret

--- a/c/caesar.c
+++ b/c/caesar.c
@@ -2,6 +2,12 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+/*
+ * Simple Caesar cipher demonstration.
+ * Usage: ./caesar shift text
+ * Not intended for real cryptographic use.
+ */
+
 int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr, "usage: %s shift text\n", argv[0]);

--- a/c/caesar.c
+++ b/c/caesar.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s shift text\n", argv[0]);
+        return 1;
+    }
+    int shift = atoi(argv[1]);
+    for (int i = 2; i < argc; i++) {
+        char *p = argv[i];
+        if (i > 2) putchar(' ');
+        for (; *p; p++) {
+            if (isalpha((unsigned char)*p)) {
+                char base = isupper((unsigned char)*p) ? 'A' : 'a';
+                putchar(((*p - base + shift) % 26) + base);
+            } else {
+                putchar(*p);
+            }
+        }
+    }
+    putchar('\n');
+    return 0;
+}

--- a/c/enigma.c
+++ b/c/enigma.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+static const char *rotor = "EKMFLGDQVZNTOWYHXUSPAIBRCJ";
+static const char *reflector = "YRUHQSLDPXNGOKMIEBFZCWVJAT";
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s text\n", argv[0]);
+        return 1;
+    }
+    int pos = 0;
+    for (int i = 1; i < argc; i++) {
+        char *p = argv[i];
+        if (i > 1) putchar(' ');
+        for (; *p; p++) {
+            if (isalpha((unsigned char)*p)) {
+                int base = 'A';
+                int idx = toupper((unsigned char)*p) - base;
+                int step1 = (idx + pos) % 26;
+                int step2 = rotor[step1] - base;
+                int step3 = reflector[step2] - base;
+                int step4 = strchr(rotor, step3 + base) - rotor;
+                int enc = (step4 - pos + 26) % 26;
+                char out = enc + base;
+                if (islower((unsigned char)*p)) out = tolower(out);
+                putchar(out);
+                pos = (pos + 1) % 26;
+            } else {
+                putchar(*p);
+            }
+        }
+    }
+    putchar('\n');
+    return 0;
+}

--- a/c/enigma.c
+++ b/c/enigma.c
@@ -2,6 +2,12 @@
 #include <ctype.h>
 #include <string.h>
 
+/*
+ * Toy Enigma cipher demonstration with a single rotor and reflector.
+ * Usage: ./enigma text
+ * Not intended for real cryptographic use.
+ */
+
 static const char *rotor = "EKMFLGDQVZNTOWYHXUSPAIBRCJ";
 static const char *reflector = "YRUHQSLDPXNGOKMIEBFZCWVJAT";
 

--- a/c/vigenere.c
+++ b/c/vigenere.c
@@ -3,6 +3,12 @@
 #include <ctype.h>
 #include <string.h>
 
+/*
+ * Simple Vigenere cipher demonstration.
+ * Usage: ./vigenere KEY text
+ * Not intended for real cryptographic use.
+ */
+
 int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr, "usage: %s key text\n", argv[0]);

--- a/c/vigenere.c
+++ b/c/vigenere.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s key text\n", argv[0]);
+        return 1;
+    }
+    char *key = argv[1];
+    int key_len = strlen(key);
+    int j = 0;
+    for (int i = 2; i < argc; i++) {
+        char *p = argv[i];
+        if (i > 2) putchar(' ');
+        for (; *p; p++) {
+            if (isalpha((unsigned char)*p)) {
+                char base = isupper((unsigned char)*p) ? 'A' : 'a';
+                int shift = tolower(key[j % key_len]) - 'a';
+                putchar(((*p - base + shift) % 26) + base);
+                j++;
+            } else {
+                putchar(*p);
+            }
+        }
+    }
+    putchar('\n');
+    return 0;
+}

--- a/py/caesar.py
+++ b/py/caesar.py
@@ -1,0 +1,19 @@
+import sys
+
+def caesar(text, shift):
+    res = []
+    for ch in text:
+        if ch.isalpha():
+            base = ord('A') if ch.isupper() else ord('a')
+            res.append(chr((ord(ch) - base + shift) % 26 + base))
+        else:
+            res.append(ch)
+    return ''.join(res)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print('usage: python caesar.py shift text')
+        sys.exit(1)
+    shift = int(sys.argv[1])
+    text = ' '.join(sys.argv[2:])
+    print(caesar(text, shift))

--- a/py/caesar.py
+++ b/py/caesar.py
@@ -1,3 +1,5 @@
+"""Simple Caesar cipher demonstration."""
+
 import sys
 
 def caesar(text, shift):

--- a/py/enigma.py
+++ b/py/enigma.py
@@ -1,0 +1,29 @@
+import sys
+
+rotor = 'EKMFLGDQVZNTOWYHXUSPAIBRCJ'
+reflector = 'YRUHQSLDPXNGOKMIEBFZCWVJAT'
+
+def enigma(text):
+    pos = 0
+    res = []
+    for ch in text:
+        if ch.isalpha():
+            base = ord('A')
+            idx = ord(ch.upper()) - base
+            step1 = (idx + pos) % 26
+            step2 = ord(rotor[step1]) - base
+            step3 = ord(reflector[step2]) - base
+            step4 = rotor.index(chr(step3 + base))
+            out = (step4 - pos) % 26
+            char = chr(out + base)
+            if ch.islower():
+                char = char.lower()
+            res.append(char)
+            pos = (pos + 1) % 26
+        else:
+            res.append(ch)
+    return ''.join(res)
+
+if __name__ == '__main__':
+    text = ' '.join(sys.argv[1:])
+    print(enigma(text))

--- a/py/enigma.py
+++ b/py/enigma.py
@@ -1,3 +1,5 @@
+"""Toy Enigma cipher demonstration with a single rotor."""
+
 import sys
 
 rotor = 'EKMFLGDQVZNTOWYHXUSPAIBRCJ'

--- a/py/vigenere.py
+++ b/py/vigenere.py
@@ -1,3 +1,5 @@
+"""Simple Vigenere cipher demonstration."""
+
 import sys
 
 def vigenere(text, key):

--- a/py/vigenere.py
+++ b/py/vigenere.py
@@ -1,0 +1,23 @@
+import sys
+
+def vigenere(text, key):
+    res = []
+    j = 0
+    klen = len(key)
+    for ch in text:
+        if ch.isalpha():
+            base = ord('A') if ch.isupper() else ord('a')
+            shift = ord(key[j % klen].lower()) - ord('a')
+            res.append(chr((ord(ch) - base + shift) % 26 + base))
+            j += 1
+        else:
+            res.append(ch)
+    return ''.join(res)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print('usage: python vigenere.py key text')
+        sys.exit(1)
+    key = sys.argv[1]
+    text = ' '.join(sys.argv[2:])
+    print(vigenere(text, key))


### PR DESCRIPTION
## Summary
- implement Caesar, Vigenere, and toy Enigma ciphers in Python
- add equivalent C versions
- include basic NASM assembly demos of each cipher

## Testing
- `gcc c/caesar.c -o c/caesar`
- `gcc c/vigenere.c -o c/vigenere`
- `gcc c/enigma.c -o c/enigma`
- `./c/caesar 3 HELLO`
- `./c/vigenere KEY "HELLO WORLD"`
- `./c/enigma HELLO`
- `python3 py/caesar.py 3 HELLO`
- `python3 py/vigenere.py KEY "HELLO WORLD"`
- `python3 py/enigma.py HELLO`
- `nasm -f elf64 asm/caesar.asm -o asm/caesar.o`
- `gcc asm/caesar.o -no-pie -lc -o asm/caesar`
- `./asm/caesar`
- `nasm -f elf64 asm/vigenere.asm -o asm/vigenere.o`
- `gcc asm/vigenere.o -no-pie -lc -o asm/vigenere`
- `./asm/vigenere`
- `nasm -f elf64 asm/enigma.asm -o asm/enigma.o`
- `gcc asm/enigma.o -no-pie -lc -o asm/enigma`
- `./asm/enigma`


------
https://chatgpt.com/codex/tasks/task_e_68402fe130e0832e9beb3a7324284b84