### PR TITLE
Add SSLKEYLOGFILE helper scripts

### DIFF
--- a/sslkeylog/README.md
+++ b/sslkeylog/README.md
@@ -1,0 +1,34 @@
+# SSLKEYLOGFILE Helper Scripts
+
+This folder contains small scripts to set the `SSLKEYLOGFILE` environment
+variable on Linux and Windows. The variable instructs compatible applications
+(e.g. browsers or command line tools using OpenSSL) to log TLS session keys to a
+file so the traffic can be decrypted in debugging tools like Wireshark.
+
+## Linux
+
+Source the script to set the variable for your shell:
+
+```bash
+source ./linux/set_sslkeylog.sh
+```
+
+Optionally provide a path to the log file:
+
+```bash
+source ./linux/set_sslkeylog.sh /tmp/mykeys.log
+```
+
+## Windows
+
+Run the PowerShell script in your session:
+
+```powershell
+.\windows\set_sslkeylog.ps1
+```
+
+Provide a custom file path if desired:
+
+```powershell
+.\windows\set_sslkeylog.ps1 -LogFile C:\\temp\\keys.log
+```

--- a/sslkeylog/linux/set_sslkeylog.sh
+++ b/sslkeylog/linux/set_sslkeylog.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Simple script to set SSLKEYLOGFILE for the current shell
+# Usage: source ./set_sslkeylog.sh [log_file]
+
+LOG_FILE="$1"
+if [ -z "$LOG_FILE" ]; then
+  LOG_FILE="$HOME/sslkeylog.log"
+fi
+export SSLKEYLOGFILE="$LOG_FILE"
+echo "SSLKEYLOGFILE set to $SSLKEYLOGFILE"

--- a/sslkeylog/windows/set_sslkeylog.ps1
+++ b/sslkeylog/windows/set_sslkeylog.ps1
@@ -1,0 +1,8 @@
+# PowerShell script to set SSLKEYLOGFILE for the current session
+# Usage: .\set_sslkeylog.ps1 [log_file]
+
+param(
+    [string]$LogFile = "$env:USERPROFILE\sslkeylog.log"
+)
+$env:SSLKEYLOGFILE = $LogFile
+Write-Output "SSLKEYLOGFILE set to $env:SSLKEYLOGFILE"


### PR DESCRIPTION
## Summary
- add helper scripts for capturing SSL/TLS secrets via the SSLKEYLOGFILE env variable
- provide a README with usage examples for Linux and Windows

## Testing
- `make -C c`
- `python python/analyze.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68403c23b0b8832e9258d87195ede7c6