### PR TITLE
Add insecure and secure RNG demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository now includes simple cipher analysis tools in four languages:
 
-- `python/`: command line utilities for Caesar, Vigenère, and a simplified Enigma simulator.
+- `python/`: command line utilities for Caesar, Vigenère, a simplified Enigma simulator, and RNG demonstrations (insecure and secure).
 - `c/`: minimal CLI tool demonstrating Caesar and Vigenère breaking.
 - `asm/`: x86-64 assembly program to brute force Caesar.
 - `bash/`: shell script performing basic Caesar and Vigenère operations.

--- a/python/README.md
+++ b/python/README.md
@@ -5,5 +5,9 @@ This directory provides analysis tools for classic ciphers:
 - **Caesar**: brute force decryption of all possible shifts.
 - **Vigenere**: estimate key from frequency analysis given a key length.
 - **Enigma**: simplified rotor/plugboard simulation.
+- **insecure_rng**: demonstrates a Dual EC DRBG style random generator that
+  is intentionally insecure. **Do not use in production!**
+- **secure_rng**: example wrapper around Python's cryptographically secure
+  `secrets` module.
 
 Run `python analyze.py --help` for options.

--- a/python/insecure_rng.py
+++ b/python/insecure_rng.py
@@ -1,0 +1,41 @@
+"""Dual EC DRBG style insecure random number generator.
+
+WARNING: This implementation is intentionally insecure and provided
+only for demonstration purposes. Do NOT use for real cryptographic
+applications or in production systems.
+"""
+
+import os
+
+# These constants are taken from the NIST P-256 curve but the output
+# generation is intentionally flawed and predictable.
+P = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
+Q = 0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+G = 0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162cb13b12a14cdbdb1cb4c20ad0c6f1e2
+
+class DualECDRBG:
+    """Very simplified and insecure Dual_EC_DRBG-like generator."""
+
+    def __init__(self, seed: int | None = None) -> None:
+        if seed is None:
+            seed = int.from_bytes(os.urandom(32), "big")
+        self.state = seed % P
+
+    def next_bytes(self, nbytes: int = 32) -> bytes:
+        # The real algorithm uses elliptic curve point multiplication.
+        # Here we use a trivial modular squaring step followed by a
+        # predictable linear transformation, which is insecure.
+        self.state = pow(self.state, 2, P)
+        r = (self.state * Q) % P
+        out = (r * G) % P
+        return out.to_bytes(64, "big")[:nbytes]
+
+
+def demo() -> None:
+    rng = DualECDRBG()
+    for _ in range(5):
+        print(rng.next_bytes(16).hex())
+
+
+if __name__ == "__main__":
+    demo()

--- a/python/secure_rng.py
+++ b/python/secure_rng.py
@@ -1,0 +1,19 @@
+"""Secure random number generator wrapper using Python's secrets module."""
+
+import secrets
+
+class SecureRNG:
+    """Provides cryptographically strong random bytes."""
+
+    def next_bytes(self, nbytes: int = 32) -> bytes:
+        return secrets.token_bytes(nbytes)
+
+
+def demo() -> None:
+    rng = SecureRNG()
+    for _ in range(5):
+        print(rng.next_bytes(16).hex())
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary
- demonstrate an insecure Dual EC DRBG-style RNG with a clear warning
- document the insecure RNG and add a secure RNG wrapper using Python's `secrets`

## Testing
- `python -m py_compile python/insecure_rng.py`
- `python -m py_compile python/secure_rng.py`
- `python -m py_compile python/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68406de31210832e87dabd33bc70808e