### PR TITLE
Add Dual_EC_DRBG examples

### DIFF
--- a/asm/dual_ec_drbg.asm
+++ b/asm/dual_ec_drbg.asm
@@ -1,0 +1,16 @@
+; Minimal assembly wrapper calling C Dual_EC_DRBG
+; nasm -felf64 dual_ec_drbg.asm && gcc dual_ec_drbg.o ../c/dual_ec_drbg.c -o dual_ec_drbg
+
+section .text
+    global main
+    extern dual_ec_drbg
+
+main:
+    push rbp
+    mov rbp, rsp
+    mov edi, 7      ; seed
+    mov esi, 5      ; blocks
+    call dual_ec_drbg
+    mov eax, 0
+    pop rbp
+    ret

--- a/bash/dual_ec_drbg.sh
+++ b/bash/dual_ec_drbg.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Pure bash Dual_EC_DRBG demo with small curve
+p=233
+A=1
+Px=3
+Py=65
+Qx=83
+Qy=97
+seed=${1:-7}
+blocks=${2:-5}
+
+inv_mod() {
+  local a=$1
+  local p=$2
+  for ((i=1;i<p;i++)); do
+    if (( (a*i) % p == 1 )); then
+      echo $i
+      return
+    fi
+  done
+}
+
+add_point() {
+  local x1=$1 y1=$2 x2=$3 y2=$4
+  if (( x1 == -1 )); then echo "$x2 $y2"; return; fi
+  if (( x2 == -1 )); then echo "$x1 $y1"; return; fi
+  if (( x1==x2 && (y1 + y2) % p == 0 )); then
+    echo "-1 0"
+    return
+  fi
+  local m
+  if (( x1==x2 && y1==y2 )); then
+    local denom=$(( (2*y1) % p ))
+    local inv=$(inv_mod $denom $p)
+    m=$(( (3*x1*x1 + A)*inv % p ))
+  else
+    local denom=$(( (x2 - x1 + p) % p ))
+    local inv=$(inv_mod $denom $p)
+    m=$(( ( (y2 - y1 + p) % p ) * inv % p ))
+  fi
+  local x3=$(( (m*m - x1 - x2) % p ))
+  if (( x3 < 0 )); then x3=$((x3+p)); fi
+  local y3=$(( (m*(x1 - x3) - y1) % p ))
+  if (( y3 < 0 )); then y3=$((y3+p)); fi
+  echo "$x3 $y3"
+}
+
+mul_point() {
+  local k=$1 x=$2 y=$3
+  local hx=-1 hy=0
+  while (( k>0 )); do
+    if (( k & 1 )); then
+      read hx hy <<<$(add_point $hx $hy $x $y)
+    fi
+    read x y <<<$(add_point $x $y $x $y)
+    k=$((k>>1))
+  done
+  echo "$hx $hy"
+}
+
+for ((i=0;i<blocks;i++)); do
+  read sx sy <<<$(mul_point $seed $Px $Py)
+  seed=$sx
+  read rx ry <<<$(mul_point $seed $Qx $Qy)
+  echo $rx
+  seed=$sx
+done

--- a/c/dual_ec_drbg.c
+++ b/c/dual_ec_drbg.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define P_FIELD 233
+#define A_COEFF 1
+
+typedef struct {
+    int64_t x;
+    int64_t y;
+    int inf;
+} Point;
+
+static int64_t mod_inv(int64_t a, int64_t p) {
+    int64_t t = 0, newt = 1;
+    int64_t r = p, newr = a % p;
+    while (newr != 0) {
+        int64_t q = r / newr;
+        int64_t tmp = newt;
+        newt = t - q * newt;
+        t = tmp;
+        tmp = newr;
+        newr = r - q * newr;
+        r = tmp;
+    }
+    if (r > 1) return -1;
+    if (t < 0) t += p;
+    return t;
+}
+
+static Point point_add(Point P, Point Q) {
+    if (P.inf) return Q;
+    if (Q.inf) return P;
+    if (P.x == Q.x && (P.y + Q.y) % P_FIELD == 0) {
+        Point R = {0,0,1};
+        return R;
+    }
+    int64_t m;
+    if (P.x != Q.x || P.y != Q.y) {
+        int64_t denom = (Q.x - P.x) % P_FIELD;
+        if (denom < 0) denom += P_FIELD;
+        m = ((Q.y - P.y) * mod_inv(denom, P_FIELD)) % P_FIELD;
+    } else {
+        int64_t denom = (2 * P.y) % P_FIELD;
+        m = ((3 * P.x * P.x + A_COEFF) * mod_inv(denom, P_FIELD)) % P_FIELD;
+    }
+    if (m < 0) m += P_FIELD;
+    int64_t x3 = (m * m - P.x - Q.x) % P_FIELD;
+    if (x3 < 0) x3 += P_FIELD;
+    int64_t y3 = (m * (P.x - x3) - P.y) % P_FIELD;
+    if (y3 < 0) y3 += P_FIELD;
+    Point R = {x3, y3, 0};
+    return R;
+}
+
+static Point point_mul(int64_t k, Point P) {
+    Point R = {0,0,1};
+    while (k > 0) {
+        if (k & 1) R = point_add(R, P);
+        P = point_add(P, P);
+        k >>= 1;
+    }
+    return R;
+}
+
+void dual_ec_drbg(int64_t seed, int blocks) {
+    Point G = {3, 65, 0};
+    Point Q = {83, 97, 0};
+    int64_t s = seed;
+    for (int i = 0; i < blocks; i++) {
+        Point sP = point_mul(s, G);
+        s = sP.x % P_FIELD;
+        Point rP = point_mul(s, Q);
+        printf("%ld\n", rP.x % P_FIELD);
+    }
+}
+
+#ifndef NO_MAIN
+int main(int argc, char **argv) {
+    int64_t seed = 7;
+    int blocks = 5;
+    if (argc > 1) seed = atoll(argv[1]);
+    if (argc > 2) blocks = atoi(argv[2]);
+    dual_ec_drbg(seed, blocks);
+    return 0;
+}
+#endif

--- a/python/dual_ec_drbg.py
+++ b/python/dual_ec_drbg.py
@@ -1,0 +1,52 @@
+P = (3, 65)
+Q = (83, 97)
+p = 233
+A = 1
+
+# Elliptic curve utilities over F_p
+
+def inv_mod(a, p):
+    """Return modular inverse of a mod p."""
+    return pow(a, -1, p)
+
+def add(Pt, Qt):
+    if Pt is None:
+        return Qt
+    if Qt is None:
+        return Pt
+    x1, y1 = Pt
+    x2, y2 = Qt
+    if x1 == x2 and (y1 + y2) % p == 0:
+        return None
+    if Pt != Qt:
+        m = ((y2 - y1) * inv_mod((x2 - x1) % p, p)) % p
+    else:
+        m = ((3 * x1 * x1 + A) * inv_mod((2 * y1) % p, p)) % p
+    x3 = (m * m - x1 - x2) % p
+    y3 = (m * (x1 - x3) - y1) % p
+    return x3, y3
+
+def mul(k, Pt):
+    result = None
+    addend = Pt
+    while k:
+        if k & 1:
+            result = add(result, addend)
+        addend = add(addend, addend)
+        k >>= 1
+    return result
+
+def dual_ec_drbg(seed, blocks=5):
+    s = seed
+    out = []
+    for _ in range(blocks):
+        s = mul(s, P)[0]
+        r = mul(s, Q)[0]
+        out.append(r)
+    return out
+
+if __name__ == "__main__":
+    from sys import argv
+    seed = int(argv[1]) if len(argv) > 1 else 7
+    blocks = int(argv[2]) if len(argv) > 2 else 5
+    print(dual_ec_drbg(seed, blocks))


### PR DESCRIPTION
## Summary
- implement a small Dual_EC_DRBG demo in Python
- add equivalent implementation in C
- provide a pure bash version using integer arithmetic
- show an assembly wrapper that calls the C implementation

## Testing
- `python3 -m py_compile python/dual_ec_drbg.py`
- `python3 python/dual_ec_drbg.py 7 5`
- `bash/dual_ec_drbg.sh 7 5`
- `gcc -c c/dual_ec_drbg.c -o c/dual_ec_drbg.o -DNO_MAIN`
- `nasm -felf64 asm/dual_ec_drbg.asm -o asm/dual_ec_drbg.o`
- `gcc asm/dual_ec_drbg.o c/dual_ec_drbg.o -o asm/dual_ec_drbg`
- `./asm/dual_ec_drbg`


------
https://chatgpt.com/codex/tasks/task_e_68406e086174832eb5648e7f35c25372