### PR TITLE
Add Go GUI cipher helper

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,17 @@
+# Go GUI Cipher Helper
+
+This directory contains a Go rewrite of the Python GUI for breaking
+Caesar ciphers and decrypting Vigenère text. The program uses the
+[Fyne](https://fyne.io/) toolkit to create the interface.
+
+## Building
+
+```
+cd go
+go build
+```
+
+Make sure you have Go installed and can fetch modules from the internet.
+If module download fails in your environment, you may need to adjust the
+go proxy or provide the dependencies manually.
+```

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/gui_crypto
+
+go 1.23.8

--- a/go/gui_crypto.go
+++ b/go/gui_crypto.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/widget"
+)
+
+// ALPHABET provides the letter order for Caesar and Vigenere.
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// caesarBreak returns all 26 Caesar shift attempts for the given text.
+func caesarBreak(text string) string {
+	text = strings.ToUpper(text)
+	var lines []string
+	for shift := 0; shift < 26; shift++ {
+		var out strings.Builder
+		for _, ch := range text {
+			idx := strings.IndexRune(ALPHABET, ch)
+			if idx >= 0 {
+				// rotate alphabet backwards by shift
+				idx = (idx - shift + 26) % 26
+				out.WriteByte(ALPHABET[idx])
+			} else {
+				out.WriteRune(ch)
+			}
+		}
+		lines = append(lines, fmt.Sprintf("%2d: %s", shift, out.String()))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// vigenereDecrypt performs classic Vigenere decryption using key letters as shifts.
+func vigenereDecrypt(text, key string) string {
+	if key == "" {
+		return "⚠️  Key required for Vigenère"
+	}
+	text = strings.ToUpper(text)
+	key = strings.ToUpper(key)
+	keyLen := len(key)
+	var out strings.Builder
+	k := 0
+	for _, ch := range text {
+		idx := strings.IndexRune(ALPHABET, ch)
+		if idx >= 0 {
+			shift := strings.IndexRune(ALPHABET, rune(key[k]))
+			idx = (idx - shift + 26) % 26
+			out.WriteByte(ALPHABET[idx])
+			k = (k + 1) % keyLen
+		} else {
+			out.WriteRune(ch)
+		}
+	}
+	return out.String()
+}
+
+func main() {
+	// Create the application window.
+	a := app.New()
+	w := a.NewWindow("Simple Cipher Helper")
+
+	// ---- Widgets ----
+
+	// radio buttons choose the cipher
+	cipher := widget.NewRadioGroup([]string{"Caesar (show all shifts)", "Vigenère"}, nil)
+	cipher.SetSelected("Caesar (show all shifts)")
+
+	// key entry - used only for Vigenere
+	keyEntry := widget.NewEntry()
+
+	// text input for the ciphertext
+	textBox := widget.NewMultiLineEntry()
+	textBox.SetPlaceHolder("Enter ciphertext here")
+
+	// output area is read-only
+	outBox := widget.NewMultiLineEntry()
+	outBox.Disable()
+
+	// button to run decryption
+	runBtn := widget.NewButton("Decrypt / Break", func() {
+		txt := strings.TrimSpace(textBox.Text)
+		if txt == "" {
+			outBox.SetText("Please enter ciphertext first")
+			return
+		}
+		if cipher.Selected == "Caesar (show all shifts)" {
+			outBox.SetText(caesarBreak(txt))
+		} else {
+			outBox.SetText(vigenereDecrypt(txt, strings.TrimSpace(keyEntry.Text)))
+		}
+	})
+
+	// clear button resets text fields
+	clearBtn := widget.NewButton("Clear", func() {
+		textBox.SetText("")
+		outBox.SetText("")
+	})
+
+	// hide or show key entry depending on cipher choice
+	cipher.OnChanged = func(s string) {
+		if s == "Vigenère" {
+			keyEntry.Enable()
+		} else {
+			keyEntry.Disable()
+		}
+	}
+	cipher.OnChanged(cipher.Selected) // set initial state
+
+	// layout using vertical boxes like nodes stacked together
+	w.SetContent(container.NewVBox(
+		container.New(layout.NewFormLayout(), widget.NewLabel("Cipher:"), cipher),
+		container.New(layout.NewFormLayout(), widget.NewLabel("Key:"), keyEntry),
+		widget.NewLabel("Ciphertext:"), textBox,
+		container.NewHBox(runBtn, clearBtn),
+		widget.NewLabel("Output:"), outBox,
+	))
+
+	w.Resize(fyne.NewSize(600, 400))
+	w.ShowAndRun()
+}


### PR DESCRIPTION
## Summary
- create a new `go` folder with a GUI cipher helper written in Go
- port Python Caesar/Vigenère GUI to Fyne
- add module setup and build instructions in `go/README.md`

## Testing
- `go build` *(fails: missing Fyne modules)*

------
https://chatgpt.com/codex/tasks/task_e_68415466dffc832e82e0161c2f26a50a