### PR TITLE
Add beginner-friendly ML notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ This repository now includes simple cipher analysis tools in four languages:
 - `c/`: minimal CLI tool demonstrating Caesar and Vigenère breaking.
 - `asm/`: x86-64 assembly program to brute force Caesar.
 - `bash/`: shell script performing basic Caesar and Vigenère operations.
+- `notebooks/`: beginner-friendly Jupyter notebooks with widgets for simple
+  machine learning tasks using scikit-learn and Keras.
 
 Each directory contains a README with usage examples.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Jupyter Notebook Helpers
+
+This directory contains simple notebooks demonstrating basic machine learning tasks with interactive widgets.
+
+- **linear_regression_helper.ipynb**: Load a CSV and train a linear regression model using scikit-learn.
+- **simple_mnist_classifier.ipynb**: Train a small neural network on the MNIST dataset with Keras.
+- **kmeans_clustering_helper.ipynb**: Upload data and run KMeans clustering with scikit-learn.
+
+Each notebook uses `ipywidgets` to adjust parameters and save results.

--- a/notebooks/kmeans_clustering_helper.ipynb
+++ b/notebooks/kmeans_clustering_helper.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KMeans Clustering Helper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.cluster import KMeans\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "import io\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload = widgets.FileUpload(accept='.csv', multiple=False)\n",
+    "clusters = widgets.IntSlider(value=3, min=2, max=10, step=1, description='Clusters')\n",
+    "run_button = widgets.Button(description='Cluster')\n",
+    "output = widgets.Output()\n",
+    "display(upload, clusters, run_button, output)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def on_cluster_clicked(b):\n",
+    "    with output:\n",
+    "        output.clear_output()\n",
+    "        if len(upload.value) == 0:\n",
+    "            print(\"Upload CSV data first.\")\n",
+    "            return\n",
+    "        content = list(upload.value.values())[0]['content']\n",
+    "        df = pd.read_csv(io.BytesIO(content))\n",
+    "        kmeans = KMeans(n_clusters=clusters.value)\n",
+    "        labels = kmeans.fit_predict(df)\n",
+    "        df[\"cluster\"] = labels\n",
+    "        df.to_csv(\"clustered.csv\", index=False)\n",
+    "        print(\"Clustered data saved to clustered.csv\")\n",
+    "        display(df.head())\n",
+    "\n",
+    "run_button.on_click(on_cluster_clicked)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/linear_regression_helper.ipynb
+++ b/notebooks/linear_regression_helper.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Linear Regression Helper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "import joblib, io\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload = widgets.FileUpload(accept='.csv', multiple=False)\n",
+    "display(upload)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_data(upload):\n",
+    "    if len(upload.value) > 0:\n",
+    "        content = list(upload.value.values())[0]['content']\n",
+    "        df = pd.read_csv(io.BytesIO(content))\n",
+    "        return df\n",
+    "    return pd.DataFrame()\n",
+    "\n",
+    "df = load_data(upload)\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_size = widgets.FloatSlider(value=0.2, min=0.1, max=0.9, step=0.1, description='Test Size:')\n",
+    "train_button = widgets.Button(description='Train Model')\n",
+    "output = widgets.Output()\n",
+    "display(test_size, train_button, output)\n",
+    "\n",
+    "def on_train_clicked(b):\n",
+    "    with output:\n",
+    "        output.clear_output()\n",
+    "        if df.empty:\n",
+    "            print(\"Upload a CSV file first.\")\n",
+    "            return\n",
+    "        X = df.iloc[:, :-1]\n",
+    "        y = df.iloc[:, -1]\n",
+    "        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size.value, random_state=42)\n",
+    "        model = LinearRegression()\n",
+    "        model.fit(X_train, y_train)\n",
+    "        score = model.score(X_test, y_test)\n",
+    "        joblib.dump(model, \"linear_model.joblib\")\n",
+    "        print(f\"Test R^2: {score:.3f}\")\n",
+    "        print(\"Model saved to linear_model.joblib\")\n",
+    "\n",
+    "train_button.on_click(on_train_clicked)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/simple_mnist_classifier.ipynb
+++ b/notebooks/simple_mnist_classifier.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple MNIST Classifier using Keras"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = widgets.IntSlider(value=5, min=1, max=20, step=1, description='Epochs')\n",
+    "batch_size = widgets.IntSlider(value=32, min=16, max=128, step=16, description='Batch Size')\n",
+    "train_button = widgets.Button(description='Train')\n",
+    "output = widgets.Output()\n",
+    "display(epochs, batch_size, train_button, output)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def on_train_clicked(b):\n",
+    "    with output:\n",
+    "        output.clear_output()\n",
+    "        (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+    "        x_train = x_train.reshape(-1, 28*28).astype(\"float32\") / 255\n",
+    "        x_test = x_test.reshape(-1, 28*28).astype(\"float32\") / 255\n",
+    "        model = keras.Sequential([\n",
+    "            layers.Dense(128, activation=\"relu\", input_shape=(28*28,)),\n",
+    "            layers.Dense(10, activation=\"softmax\")\n",
+    "        ])\n",
+    "        model.compile(optimizer=\"adam\", loss=\"sparse_categorical_crossentropy\", metrics=[\"accuracy\"])\n",
+    "        model.fit(x_train, y_train, epochs=epochs.value, batch_size=batch_size.value, verbose=0)\n",
+    "        loss, acc = model.evaluate(x_test, y_test, verbose=0)\n",
+    "        model.save(\"mnist_model.h5\")\n",
+    "        print(f\"Test accuracy: {acc:.3f}\")\n",
+    "        print(\"Model saved to mnist_model.h5\")\n",
+    "\n",
+    "train_button.on_click(on_train_clicked)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add Jupyter notebooks with widgets for linear regression, MNIST classification and KMeans clustering
- document the new notebooks in repository README
- create a README in the notebooks folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df58beec832ebe86d143e83bf790