### PR TITLE
Add Antikythera simulation with two GUIs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -9,5 +9,7 @@ This directory provides analysis tools for classic ciphers:
   is intentionally insecure. **Do not use in production!**
 - **secure_rng**: example wrapper around Python's cryptographically secure
   `secrets` module.
+- **antikythera**: simplified astronomical simulation with both Tkinter
+  and PySimpleGUI interfaces.
 
 Run `python analyze.py --help` for options.

--- a/python/antikythera.py
+++ b/python/antikythera.py
@@ -1,0 +1,66 @@
+"""Simplified Antikythera mechanism simulation."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+
+@dataclass
+class Gear:
+    """Represents a simple gear with a rotation period in days."""
+
+    period: float  # days for a full rotation
+    angle: float = 0.0  # current angle in degrees
+
+    def update(self, days: float) -> None:
+        self.angle = (days % self.period) / self.period * 360.0
+
+
+class Antikythera:
+    """Minimal model of the Antikythera mechanism."""
+
+    def __init__(self, start_date: datetime.date | None = None) -> None:
+        if start_date is None:
+            start_date = datetime.date.today()
+        self.start_date = start_date
+        self.sun = Gear(365.25)
+        self.moon = Gear(29.53)  # synodic month
+        self.metonic = Gear(365.25 * 19)  # 19-year cycle
+
+    def update_for(self, date: datetime.date) -> None:
+        days = (date - self.start_date).days
+        self.sun.update(days)
+        self.moon.update(days)
+        self.metonic.update(days)
+
+    def moon_phase(self) -> str:
+        phase_angle = self.moon.angle % 360
+        phase = (phase_angle / 360) * 8
+        idx = int(phase + 0.5) % 8
+        names = [
+            "New Moon",
+            "Waxing Crescent",
+            "First Quarter",
+            "Waxing Gibbous",
+            "Full Moon",
+            "Waning Gibbous",
+            "Last Quarter",
+            "Waning Crescent",
+        ]
+        return names[idx]
+
+    def info(self) -> str:
+        return (
+            f"Sun angle: {self.sun.angle:.1f}\n"
+            f"Moon angle: {self.moon.angle:.1f}\n"
+            f"Metonic angle: {self.metonic.angle:.1f}\n"
+            f"Moon phase: {self.moon_phase()}"
+        )
+
+
+if __name__ == "__main__":
+    mech = Antikythera()
+    today = datetime.date.today()
+    mech.update_for(today)
+    print(mech.info())

--- a/python/antikythera_gui_psg.py
+++ b/python/antikythera_gui_psg.py
@@ -1,0 +1,35 @@
+"""PySimpleGUI version of the Antikythera mechanism interface."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import PySimpleGUI as sg
+
+from antikythera import Antikythera
+
+
+def main() -> None:
+    mech = Antikythera()
+    layout = [
+        [sg.Text("Date (YYYY-MM-DD):"), sg.Input(date.today().isoformat(), key="-DATE-")],
+        [sg.Button("Update")],
+        [sg.Multiline(size=(40, 6), key="-OUT-")],
+    ]
+    window = sg.Window("Antikythera - PySimpleGUI", layout)
+    while True:
+        event, values = window.read()
+        if event in (sg.WIN_CLOSED, "Exit"):
+            break
+        if event == "Update":
+            try:
+                d = date.fromisoformat(values["-DATE-"])
+            except ValueError:
+                continue
+            mech.update_for(d)
+            window["-OUT-"].update(mech.info())
+    window.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/antikythera_gui_tk.py
+++ b/python/antikythera_gui_tk.py
@@ -1,0 +1,41 @@
+"""Tkinter GUI for the simplified Antikythera mechanism."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from datetime import date
+
+from antikythera import Antikythera
+
+
+class App(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Antikythera - Tkinter")
+        self.mech = Antikythera()
+        self.date_var = tk.StringVar(value=date.today().isoformat())
+
+        tk.Label(self, text="Date (YYYY-MM-DD):").pack(pady=2)
+        tk.Entry(self, textvariable=self.date_var).pack(pady=2)
+        tk.Button(self, text="Update", command=self.update_info).pack(pady=2)
+
+        self.text = tk.Text(self, width=40, height=6, state="disabled")
+        self.text.pack(padx=5, pady=5)
+
+        self.update_info()
+
+    def update_info(self) -> None:
+        try:
+            d = date.fromisoformat(self.date_var.get())
+        except ValueError:
+            return
+        self.mech.update_for(d)
+        info = self.mech.info()
+        self.text.configure(state="normal")
+        self.text.delete("1.0", "end")
+        self.text.insert("1.0", info)
+        self.text.configure(state="disabled")
+
+
+if __name__ == "__main__":
+    App().mainloop()


### PR DESCRIPTION
## Summary
- implement a simplified Antikythera mechanism model
- add Tkinter GUI
- add PySimpleGUI GUI
- document new program in `python/README.md`

## Testing
- `python3 -m py_compile python/antikythera.py python/antikythera_gui_tk.py python/antikythera_gui_psg.py`


------
https://chatgpt.com/codex/tasks/task_e_68458d647af4832e9ab76a75d5d2b0b4