### PR TITLE
Add C and ASM tutorial examples

### DIFF
--- a/c_asm_tutorial/README.md
+++ b/c_asm_tutorial/README.md
@@ -1,0 +1,9 @@
+# C and Assembly Tutorials
+
+This folder provides small programs grouped by difficulty to help you learn the basics of C and x86-64 assembly.
+
+- **beginner** – Minimal "Hello, world" programs.
+- **intermediate** – Examples with loops and functions.
+- **advanced** – Simple file input/output.
+
+Each subdirectory contains a README with compilation instructions.

--- a/c_asm_tutorial/advanced/README.md
+++ b/c_asm_tutorial/advanced/README.md
@@ -1,0 +1,16 @@
+# Advanced Level
+
+Here we show basic file I/O in both C and assembly.
+
+## C File Reader
+```
+cc filecat.c -o filecat_c
+./filecat_c example.txt
+```
+
+## Assembly File Reader
+```
+nasm -felf64 filecat.asm
+ld filecat.o -o filecat_asm
+./filecat_asm example.txt
+```

--- a/c_asm_tutorial/advanced/filecat.asm
+++ b/c_asm_tutorial/advanced/filecat.asm
@@ -1,0 +1,56 @@
+section .data
+    usage db "Usage: ./filecat <file>\n",0
+
+section .bss
+    buf resb 1024
+
+section .text
+    global _start
+
+_start:
+    ; check argc
+    mov rax, [rsp]
+    cmp rax, 2
+    je read_file
+
+    ; print usage
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, usage
+    mov rdx, 25
+    syscall
+    jmp exit
+
+read_file:
+    mov rdi, [rsp+16] ; argv[1]
+    mov rax, 2        ; sys_open
+    mov rsi, 0        ; O_RDONLY
+    syscall
+    mov r12, rax      ; store fd
+
+read_loop:
+    mov rax, 0        ; sys_read
+    mov rdi, r12
+    mov rsi, buf
+    mov rdx, 1024
+    syscall
+    cmp rax, 0
+    jle close_file
+    mov r13, rax      ; bytes read
+
+    mov rax, 1        ; sys_write
+    mov rdi, 1
+    mov rsi, buf
+    mov rdx, r13
+    syscall
+    jmp read_loop
+
+close_file:
+    mov rax, 3        ; sys_close
+    mov rdi, r12
+    syscall
+
+exit:
+    mov rax, 60
+    xor rdi, rdi
+    syscall

--- a/c_asm_tutorial/advanced/filecat.c
+++ b/c_asm_tutorial/advanced/filecat.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <file>\n", argv[0]);
+        return 1;
+    }
+    FILE *f = fopen(argv[1], "r");
+    if (!f) {
+        perror("fopen");
+        return 1;
+    }
+    int ch;
+    while ((ch = fgetc(f)) != EOF) {
+        putchar(ch);
+    }
+    fclose(f);
+    return 0;
+}

--- a/c_asm_tutorial/beginner/README.md
+++ b/c_asm_tutorial/beginner/README.md
@@ -1,0 +1,18 @@
+# Beginner Level
+
+These introductory examples demonstrate how to compile and run a basic program in C and assembly.
+
+## Compiling the C example
+
+```
+cc hello.c -o hello_c
+./hello_c
+```
+
+## Assembling the assembly example
+
+```
+nasm -felf64 hello.asm
+ld hello.o -o hello_asm
+./hello_asm
+```

--- a/c_asm_tutorial/beginner/hello.asm
+++ b/c_asm_tutorial/beginner/hello.asm
@@ -1,0 +1,17 @@
+section .data
+    msg db "Hello, world!", 0xA
+    len equ $ - msg
+
+section .text
+    global _start
+
+_start:
+    mov rax, 1          ; write
+    mov rdi, 1          ; stdout
+    mov rsi, msg
+    mov rdx, len
+    syscall
+
+    mov rax, 60         ; exit
+    xor rdi, rdi
+    syscall

--- a/c_asm_tutorial/beginner/hello.c
+++ b/c_asm_tutorial/beginner/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello, world!\n");
+    return 0;
+}

--- a/c_asm_tutorial/intermediate/README.md
+++ b/c_asm_tutorial/intermediate/README.md
@@ -1,0 +1,17 @@
+# Intermediate Level
+
+These examples expand on basic syntax with functions and loops.
+
+## Fibonacci in C
+Compiling and running:
+```
+cc fibonacci.c -o fibonacci
+./fibonacci
+```
+
+## Summing numbers in Assembly
+```
+nasm -felf64 sum10.asm
+ld sum10.o -o sum10
+./sum10
+```

--- a/c_asm_tutorial/intermediate/fibonacci.c
+++ b/c_asm_tutorial/intermediate/fibonacci.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int fib(int n) {
+    if (n <= 1) return n;
+    return fib(n-1) + fib(n-2);
+}
+
+int main(void) {
+    for (int i = 0; i < 10; ++i) {
+        printf("%d ", fib(i));
+    }
+    printf("\n");
+    return 0;
+}

--- a/c_asm_tutorial/intermediate/sum10.asm
+++ b/c_asm_tutorial/intermediate/sum10.asm
@@ -1,0 +1,26 @@
+section .text
+    global _start
+
+_start:
+    mov rcx, 10
+    xor rax, rax       ; sum = 0
+
+loop_start:
+    add rax, rcx
+    loop loop_start
+
+    ; print result (assumes result < 256)
+    add al, '0'
+    mov [res], al
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, res
+    mov rdx, 2
+    syscall
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+section .bss
+res resb 2


### PR DESCRIPTION
## Summary
- add `c_asm_tutorial` folder with beginner, intermediate, and advanced examples in C and assembly
- provide simple README guides with compilation instructions

## Testing
- `make -C c`

------
https://chatgpt.com/codex/tasks/task_e_6851bd329a5c832e99b2300751d55809