### PR TITLE
Add Python basics examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository now includes simple cipher analysis tools in four languages:
 
-- `python/`: command line utilities for Caesar, Vigenère, a simplified Enigma simulator, and RNG demonstrations (insecure and secure).
+- `python/`: command line utilities for Caesar, Vigenère, a simplified Enigma simulator, and RNG demonstrations (insecure and secure), along with basic examples in `python/basics/`.
 - `c/`: minimal CLI tool demonstrating Caesar and Vigenère breaking.
 - `asm/`: x86-64 assembly program to brute force Caesar.
 - `bash/`: shell script performing basic Caesar and Vigenère operations.

--- a/python/README.md
+++ b/python/README.md
@@ -23,3 +23,12 @@ Run `python analyze.py --help` for options.
   color selection for visualizing motion near a black hole.
 - **goldbach_comet_gui.py**: visualize Goldbach pair counts ("Goldbach's comet")
   for a selected range of even numbers.
+
+## Python Basics
+
+The `basics/` folder contains small scripts introducing core language features:
+
+- `loops.py` &mdash; examples of `for` and `while` loops.
+- `lambda_examples.py` &mdash; demonstrations of lambda functions with `map`, `filter`, and sorting.
+- `comprehensions.py` &mdash; shows list, dictionary, and set comprehensions.
+

--- a/python/basics/README.md
+++ b/python/basics/README.md
@@ -1,0 +1,10 @@
+# Python Basics Examples
+
+These small scripts demonstrate fundamental Python concepts:
+
+- **loops.py** &mdash; showcases `for` and `while` loops over different data structures.
+- **lambda_examples.py** &mdash; introduces lambda functions along with `map`, `filter`, and custom sort keys.
+- **comprehensions.py** &mdash; illustrates list, dictionary, and set comprehensions.
+
+Run them with `python loops.py`, `python lambda_examples.py`, and so on to see the output.
+

--- a/python/basics/comprehensions.py
+++ b/python/basics/comprehensions.py
@@ -1,0 +1,14 @@
+"""Showcases list and dictionary comprehensions."""
+
+# List comprehension to create squares
+squares = [n * n for n in range(5)]
+print("List of squares:", squares)
+
+# Dictionary comprehension for mapping numbers to their cubes
+cubes = {n: n ** 3 for n in range(5)}
+print("Dictionary of cubes:", cubes)
+
+# Set comprehension for unique characters in a string
+unique_chars = {c for c in "hello world" if c != ' '}
+print("Unique characters:", unique_chars)
+

--- a/python/basics/lambda_examples.py
+++ b/python/basics/lambda_examples.py
@@ -1,0 +1,20 @@
+"""Demonstrates Python lambda functions and higher-order operations."""
+
+# Simple lambda for squaring a number
+square = lambda x: x * x
+print("Square of 5:", square(5))
+
+# Using lambda with map
+nums = [1, 2, 3, 4]
+squared = list(map(lambda n: n * n, nums))
+print("Squared list via map:", squared)
+
+# Using lambda with filter
+odd = list(filter(lambda n: n % 2 == 1, nums))
+print("Odd numbers via filter:", odd)
+
+# Sorting with a lambda key
+pairs = [(1, 'b'), (2, 'a'), (3, 'c')]
+pairs.sort(key=lambda p: p[1])
+print("Pairs sorted by second element:", pairs)
+

--- a/python/basics/loops.py
+++ b/python/basics/loops.py
@@ -1,0 +1,22 @@
+"""Examples demonstrating loop constructs in Python."""
+
+# For loop over a list
+print("For loop over a list:")
+fruits = ["apple", "banana", "cherry"]
+for fruit in fruits:
+    print("  ", fruit)
+
+# While loop with a counter
+print("\nWhile loop counting down:")
+count = 3
+while count > 0:
+    print("  ", count)
+    count -= 1
+print("  Blast off!")
+
+# Looping over a dictionary
+print("\nLooping over a dictionary:")
+ages = {"Alice": 30, "Bob": 25, "Carol": 27}
+for name, age in ages.items():
+    print(f"  {name} is {age} years old")
+


### PR DESCRIPTION
## Summary
- add simple Python scripts in `python/basics` showing loops, lambda, and comprehensions
- document the new examples in `python/README.md`
- mention `python/basics` in the root README

## Testing
- `python3 -m py_compile python/basics/loops.py python/basics/lambda_examples.py python/basics/comprehensions.py`


------
https://chatgpt.com/codex/tasks/task_e_6856b9a80b64832ebb3e98d5e00c5e9a